### PR TITLE
Port to QGIS 4 / Qt6 / PyQt6 (v0.2.0)

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -23,9 +23,14 @@ from qgis.core import QgsVectorLayer
 # matplotlib import — bundled with QGIS since 3.x
 try:
     import matplotlib
-    matplotlib.use("Qt5Agg")
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-    from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+    try:
+        matplotlib.use("QtAgg")
+        from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+    except (ImportError, ValueError):
+        matplotlib.use("Qt5Agg")
+        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
     from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
     import matplotlib.dates as mdates
@@ -364,7 +369,7 @@ class AnalysisDialog(QDialog):
                 "⚠️  matplotlib non disponibile.\n"
                 "Installalo con:  pip install matplotlib"
             )
-            warn.setAlignment(Qt.AlignCenter)
+            warn.setAlignment(Qt.AlignmentFlag.AlignCenter)
             warn.setStyleSheet("color: #c0392b; font-size: 11pt; padding: 20px;")
             layout.addWidget(warn)
             layout.addWidget(self._make_close_btn())
@@ -421,7 +426,7 @@ class AnalysisDialog(QDialog):
         self._ts_ax = self._ts_fig.add_subplot(111)
         self._ts_ax.set_facecolor("#fafafa")
         self._ts_canvas = FigureCanvas(self._ts_fig)
-        self._ts_canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self._ts_canvas.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         vl.addWidget(NavigationToolbar(self._ts_canvas, widget))
         vl.addWidget(self._ts_canvas)
 
@@ -461,9 +466,9 @@ class AnalysisDialog(QDialog):
     def _build_stats_bar(self):
         """Build a compact stats summary row."""
         frame = QFrame()
-        frame.setFrameShape(QFrame.StyledPanel)
+        frame.setFrameShape(QFrame.Shape.StyledPanel)
         frame.setStyleSheet(
-            "background: #f0f4f8; border-radius: 4px; padding: 4px;"
+            "background-color: #f0f4f8; color: #222222; border-radius: 4px; padding: 4px;"
         )
         hl = QHBoxLayout(frame)
         hl.setContentsMargins(8, 4, 8, 4)
@@ -495,7 +500,7 @@ class AnalysisDialog(QDialog):
             hl.addLayout(col)
             if stats.index((label, value)) < len(stats) - 1:
                 sep = QFrame()
-                sep.setFrameShape(QFrame.VLine)
+                sep.setFrameShape(QFrame.Shape.VLine)
                 sep.setStyleSheet("color: #ccc;")
                 hl.addWidget(sep)
 
@@ -511,7 +516,7 @@ class AnalysisDialog(QDialog):
         vl = QVBoxLayout(widget)
         vl.setContentsMargins(0, 0, 0, 0)
         canvas = FigureCanvas(fig)
-        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        canvas.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         vl.addWidget(NavigationToolbar(canvas, widget))
         vl.addWidget(canvas)
         return widget

--- a/dialogs.py
+++ b/dialogs.py
@@ -50,14 +50,14 @@ class DrawRectangleTool(QgsMapTool):
         self._rubber_band   = None
         self._start_point   = None
         self._drawing       = False
-        self.setCursor(QCursor(Qt.CrossCursor))
+        self.setCursor(QCursor(Qt.CursorShape.CrossCursor))
 
     # ------------------------------------------------------------------
     # Mouse events
     # ------------------------------------------------------------------
 
     def canvasPressEvent(self, event):
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             self._start_point = self.toMapCoordinates(event.pos())
             self._drawing = True
             self._init_rubber_band()
@@ -68,7 +68,7 @@ class DrawRectangleTool(QgsMapTool):
             self._update_rubber_band(end)
 
     def canvasReleaseEvent(self, event):
-        if event.button() == Qt.LeftButton and self._drawing:
+        if event.button() == Qt.MouseButton.LeftButton and self._drawing:
             end = self.toMapCoordinates(event.pos())
             self._drawing = False
             self._clear_rubber_band()
@@ -82,7 +82,7 @@ class DrawRectangleTool(QgsMapTool):
             self._restore_previous_tool()
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Escape:
+        if event.key() == Qt.Key.Key_Escape:
             self._drawing = False
             self._clear_rubber_band()
             self.drawingCancelled.emit()
@@ -193,8 +193,8 @@ class SeismicExplorerDialog(QDialog):
         main_layout.addWidget(subtitle)
 
         separator = QFrame()
-        separator.setFrameShape(QFrame.HLine)
-        separator.setFrameShadow(QFrame.Sunken)
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
         main_layout.addWidget(separator)
 
         # Tabs
@@ -1031,11 +1031,11 @@ class SeismicExplorerDialog(QDialog):
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
 
         browser = QTextBrowser()
         browser.setOpenExternalLinks(True)
-        browser.setStyleSheet("font-size: 10pt; background: transparent;")
+        browser.setStyleSheet("QTextBrowser { font-size: 10pt; background-color: transparent; color: palette(text); }")
         browser.setHtml("""
 <style>
   body  { font-family: sans-serif; font-size: 10pt; margin: 8px 12px; }

--- a/dialogs.py
+++ b/dialogs.py
@@ -1044,11 +1044,11 @@ class SeismicExplorerDialog(QDialog):
   p     { margin: 4px 0 8px 0; line-height: 1.5; }
   ul    { margin: 4px 0 8px 18px; padding: 0; }
   li    { margin-bottom: 3px; line-height: 1.45; }
-  code  { font-family: monospace; background: #f0f0f0; padding: 1px 4px;
+  code  { font-family: monospace; background: #f0f0f0; color: #222222; padding: 1px 4px;
           border-radius: 3px; font-size: 9.5pt; }
-  .tip  { background: #eaf4fb; border-left: 3px solid #2980b9;
+  .tip  { background: #eaf4fb; color: #1a3a4a; border-left: 3px solid #2980b9;
           padding: 6px 10px; border-radius: 2px; margin: 6px 0; }
-  .warn { background: #fef9e7; border-left: 3px solid #f39c12;
+  .warn { background: #fef9e7; color: #4a3a00; border-left: 3px solid #f39c12;
           padding: 6px 10px; border-radius: 2px; margin: 6px 0; }
   a     { color: #2980b9; }
   hr    { border: none; border-top: 1px solid #ddd; margin: 14px 0; }

--- a/metadata.txt
+++ b/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=INGV Seismic Explorer
 qgisMinimumVersion=3.20
+qgisMaximumVersion=4.99
 description=Import and visualize seismic events from INGV (Istituto Nazionale di Geofisica e Vulcanologia) directly in QGIS
-version=0.1.0
+version=0.2.0
 author=Salvatore Fiandaca
 email=pigrecoinfinito@gmail.com
 about=INGV Seismic Explorer connects to the official INGV FDSNWS web services to download
@@ -29,4 +30,5 @@ experimental=True
 deprecated=False
 server=False
 changelog=
+    0.2.0 QGIS 4 / Qt6 / PyQt6 compatibility: qualified enums, matplotlib QtAgg backend, dark-theme stylesheet fixes, qgisMaximumVersion=4.99
     0.1.0 Initial release - core query, layer import and symbology


### PR DESCRIPTION
Closes #1

## Modifiche

- **dialogs.py**: enum qualificati (`Qt.CursorShape`, `Qt.MouseButton`, `Qt.Key`, `QFrame.Shape/Shadow`); stylesheet guida con `color` esplicito per `.tip`, `.warn`, `code` (fix tema scuro)
- **analysis.py**: backend matplotlib `QtAgg` (Qt6) con fallback `Qt5Agg`; `Qt.AlignmentFlag`, `QSizePolicy.Policy`, `QFrame.Shape`; `color` esplicito nello stylesheet stats bar
- **metadata.txt**: `qgisMaximumVersion=4.99`, versione `0.1.0` → `0.2.0`, changelog aggiornato

## Test

- [ ] Plugin caricato in QGIS 3.20+ senza errori
- [ ] Plugin caricato in QGIS 4.x senza errori
- [ ] Tab Guida leggibile su tema scuro Windows 11
- [ ] Download terremoti e stazioni funzionante
- [ ] Grafici analisi funzionanti

🤖 Generated with [Claude Code](https://claude.com/claude-code)